### PR TITLE
twigの文法が含まれる部分を%raw%で囲った

### DIFF
--- a/awos/a-week-of-symfony-198.markdown
+++ b/awos/a-week-of-symfony-198.markdown
@@ -3,6 +3,8 @@ layout: default
 title: A week of symfony#198 (11->17 October 2010)
 ---
 
+{% raw %}
+
 A week of symfony #198 (11->17 October 2010)
 ============================================
 
@@ -192,3 +194,5 @@ They talked about us
   * [New symfony plugin, sfAltCaptchaPlugin](http://www.lyra-cms.com/blog/2010/10/new-symfony-plugin-sfaltcaptchaplugin.html)
   * [Symfony: Symfony Day 2010 в Кёльне](http://www.charnad.com/blog/symfony-day-2010-in-cologne/)
   * [sfDoctrineGuardPlugin: Ajout de permissions et de groupes après un register](http://www.funstaff.ch/2010/10/12/sfdoctrineguardplugin-ajout-de-permissions-et-de-groupes-apres-un-register)
+
+{% endraw %}

--- a/awos/a-week-of-symfony-210.markdown
+++ b/awos/a-week-of-symfony-210.markdown
@@ -2,6 +2,7 @@
 layout: default
 title: "A week of symfony #210 (3->9 January 2011)"
 ---
+{% raw %}
 
 A week of symfony #210 (3->9 January 2011)
 ==========================================
@@ -215,3 +216,5 @@ They talked about us
   * [How to reduce admin generator query in Symfony 1.4](http://www.techiecorner.com/1963/how-to-reduce-admin-generator-query-in-symfony-1-4/)
   * [disable csrf_token ใน form ของ symfony](http://www.meteenee.com/disable-csrf_token-%E0%B9%83%E0%B8%99-form-%E0%B8%82%E0%B8%AD%E0%B8%87-symfony)
   * [PHP: Symfony 2 e i bundle](http://francescoagati.wordpress.com/2011/01/03/php-symfony-2-e-i-bundle/)
+
+{% endraw %}

--- a/awos/a-week-of-symfony-215.markdown
+++ b/awos/a-week-of-symfony-215.markdown
@@ -3,6 +3,7 @@ layout: default
 title: "A week of symfony #215 (7->13 February 2011)"
 ---
 
+{% raw %}
 A week of symfony #215 (7->13 February 2011)
 ============================================
 
@@ -136,3 +137,5 @@ They talked about us
   * [symfony live 一日目 ](http://d.hatena.ne.jp/cocoiti/20110207)
   * [sfDoctrineGuardPlugin 5.0.0のインストールと使い方](http://stack3.net/blogdev/p/447)
   * [Symfony Framework – użyteczna klasa sfContext](http://creativecoder.pl/2011/02/symfony-framework-uzyteczna-klasa-sfcontext/)
+
+{% endraw %}  


### PR DESCRIPTION
twigの ``{{``, ``}}`` で囲まれた部分がJekyllのビルド時に引っかかるので{% raw %}〜{% endraw %} で囲いました。